### PR TITLE
Set framework to v4.5 to work with MonoDevelop.Addin 0.3.0

### DIFF
--- a/Continuous.Client.MonoDevelop/Continuous.Client.MonoDevelop.csproj
+++ b/Continuous.Client.MonoDevelop/Continuous.Client.MonoDevelop.csproj
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Continuous.Client.MonoDevelop</RootNamespace>
     <AssemblyName>Continuous.Client.MonoDevelop</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,7 +40,7 @@
   <Import Project="..\Continuous.Client.Core\Continuous.Client.Core.projitems" Label="Shared" Condition="Exists('..\Continuous.Client.Core\Continuous.Client.Core.projitems')" />
   <Import Project="..\Continuous.Core\Continuous.Core.projitems" Label="Shared" Condition="Exists('..\Continuous.Core\Continuous.Core.projitems')" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\MonoDevelop.Addins.0.2.3\build\net40\MonoDevelop.Addins.targets" Condition="Exists('..\packages\MonoDevelop.Addins.0.2.3\build\net40\MonoDevelop.Addins.targets')" />
+  <Import Project="..\packages\MonoDevelop.Addins.0.3.0\build\net40\MonoDevelop.Addins.targets" Condition="Exists('..\packages\MonoDevelop.Addins.0.3.0\build\net40\MonoDevelop.Addins.targets')" />
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>

--- a/Continuous.Client.MonoDevelop/packages.config
+++ b/Continuous.Client.MonoDevelop/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoDevelop.Addins" version="0.2.3" targetFramework="net45" />
+  <package id="MonoDevelop.Addins" version="0.3.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Setting framework within proj file to override default framework within MonoDevelop.Addin 0.3.0

Ref #31 
