### PR TITLE
Support XS6

### DIFF
--- a/Continuous.Client.Core/ContinuousEnv.MonoDevelop.cs
+++ b/Continuous.Client.Core/ContinuousEnv.MonoDevelop.cs
@@ -109,23 +109,15 @@ namespace Continuous.Client
 						.Select (u => u.GetText ().ToString ())
 						.ToList ();
 
-				var deps = new List<string> ();
-				if (Declaration.BaseList != null && Declaration.BaseList.Types.Any ()) {
-					var ds =
-						Declaration.BaseList
-								   .Types
-								   .OfType<IdentifierNameSyntax> ()
-								   .Select (t => t.Identifier.Text);
+				var deps = 					Root 						.DescendantNodes() 						.OfType<IdentifierNameSyntax>()
+						.Select(n => Model.GetSymbolInfo(n))
+						.Where(s => s.Symbol.Kind == SymbolKind.NamedType)
+						.Select(n => n.Symbol.Name)
+						.Distinct() 						.ToList();
 
-					deps.AddRange (ds);
-				}
-
-				var ns =
-					Declaration.Ancestors ()
-							   .OfType<NamespaceDeclarationSyntax> ()
-							   .Where (n => n.Name is IdentifierNameSyntax)
-							   .Select (n => ((IdentifierNameSyntax)n.Name).Identifier.Text)
-							   .FirstOrDefault () ?? "";
+				var ns = 					Declaration.Ancestors() 							   .OfType<NamespaceDeclarationSyntax>()
+							   .Select(n => n.Name.GetText().ToString().Trim())
+							   .FirstOrDefault() ?? "";
 
 				// create an 'instrumented' instance of the document with watch calls
 				var rewriter = new WatchExpressionRewriter(Document.FullPath);

--- a/Continuous.Client.Core/ContinuousEnv.VisualStudio.cs
+++ b/Continuous.Client.Core/ContinuousEnv.VisualStudio.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using System.Linq;
-using EnvDTE80;
 using System.Threading;
 
 #if VISUALSTUDIO
+using EnvDTE80;
 using EnvDTE;
 using System.Windows;
 

--- a/Continuous.Client.MonoDevelop/Continuous.Client.MonoDevelop.csproj
+++ b/Continuous.Client.MonoDevelop/Continuous.Client.MonoDevelop.csproj
@@ -51,5 +51,58 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Composition.AttributedModel">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.Convention">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.Hosting">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.Runtime">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.TypedParts">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata">
+      <HintPath>..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.2.1\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.2.1\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.1\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.1\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.1\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.2.1\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.2.1\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\vb\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\vb\Microsoft.CodeAnalysis.VisualBasic.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.CSharp.1.2.1\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.CSharp.1.2.1\lib\net45\Microsoft.CodeAnalysis.CSharp.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.1\lib\portable-net45+win8\Microsoft.CodeAnalysis.VisualBasic.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.VisualBasic.1.2.1\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll" />
   </ItemGroup>
 </Project>

--- a/Continuous.Client.MonoDevelop/Pads.cs
+++ b/Continuous.Client.MonoDevelop/Pads.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Gtk;
+using MonoDevelop.Components;
 using MonoDevelop.Ide.Gui;
 
 namespace Continuous.Client.XamarinStudio
@@ -10,26 +11,26 @@ namespace Continuous.Client.XamarinStudio
 		Main,
 	}
 
-	public class MainPad : IPadContent
+	public class MainPad : PadContent
 	{
 		readonly MainPadControl control = new MainPadControl ();
 
 		#region IPadContent implementation
-		public void Initialize (IPadWindow window)
+		protected override void Initialize (IPadWindow window)
 		{
 			control.ShowAll ();
 		}
 		public void RedrawContent ()
 		{
 		}
-		public Widget Control {
+		public override Control Control {
 			get {
 				return control;
 			}
 		}
 		#endregion
 		#region IDisposable implementation
-		public void Dispose ()
+		public override void Dispose ()
 		{
 			control.Dispose ();
 		}

--- a/Continuous.Client.MonoDevelop/packages.config
+++ b/Continuous.Client.MonoDevelop/packages.config
@@ -1,5 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.CodeAnalysis" version="1.2.1" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.2.1" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.2.1" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.2.1" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.2.1" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.2.1" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.2.1" targetFramework="net45" />
+  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
   <package id="MonoDevelop.Addins" version="0.3.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="System.Collections" version="4.0.0" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net45" />
+  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net45" />
+  <package id="System.Globalization" version="4.0.0" targetFramework="net45" />
+  <package id="System.Linq" version="4.0.0" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net45" />
+  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net45" />
+  <package id="System.Runtime" version="4.0.0" targetFramework="net45" />
+  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net45" />
+  <package id="System.Threading" version="4.0.0" targetFramework="net45" />
 </packages>

--- a/addin-project.xml
+++ b/addin-project.xml
@@ -1,4 +1,4 @@
-<AddinProject appVersion="5.10">
+<AddinProject appVersion="6.0.1">
 	<Project platforms="Mac Linux Win32">
 		<AddinFile>Continuous.Client.MonoDevelop/bin/Debug/Continuous.Client.MonoDevelop.dll</AddinFile>
 		<BuildFile>Continuous.Client.MonoDevelop.sln</BuildFile>


### PR DESCRIPTION
_(Not ready to merge!)_

This PR aims to update Continuous to support XS6 by making the changes required to support the new Roslyn based architecture. It addresses #43. As I understand it, we need to do the following: 
- [x] Update non-core code to be compatible with changes in the v6 IDE apis
- [x] Modify the `ContinuousEnv.MonoDevelop.cs` file to add Rosyln-based type identification
- [x] Modify the `ContinuousEnv.MonoDevelop.cs` file to add Roslyn-based watch expression functionality
- [ ] Test it all properly, make sure things still work as expected 
- [x] Check this doesn't break the VS side of things 

To get it up and running, I skipped the watch expression functionality, so at this point we have working live-reload that I have tested in basic scenarios. I will look to add back the watch functionality and test it in more complicated ways in the coming days; to me it all looks pretty achievable. 

With XS6 support we will finally have the holy grail -- live reload + dark theme support. The future really is now! ✨
