### PR TITLE
Update NuGet to 2.0.6

### DIFF
--- a/Continuous.Server.iOS/Visualizer.iOS.cs
+++ b/Continuous.Server.iOS/Visualizer.iOS.cs
@@ -104,7 +104,7 @@ namespace Continuous.Server
 			}
 			else
 			{
-				presentedVC = new UIViewController();
+				presentedVC = new UIViewController { ModalPresentationStyle = UIModalPresentationStyle.FullScreen };
 				needsPresent = true;
 			}
 

--- a/Continuous.nuspec
+++ b/Continuous.nuspec
@@ -2,17 +2,16 @@
 <package >
   <metadata>
     <id>Continuous</id>
-    <version>2.0.5</version>
+    <version>2.0.6</version>
     <title>Continuous Coding</title>
     <authors>Frank A. Krueger</authors>
     <owners>Frank A. Krueger</owners>
-    <licenseUrl>https://github.com/praeclarum/Continuous</licenseUrl>
     <projectUrl>https://github.com/praeclarum/Continuous</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/praeclarum/Continuous/master/Documentation/Icon32.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Continuous Coding environment for .NET visualizes objects as quickly as you can code them. Get the Xamarin Studio add-in with the same name in order to use this library.</description>
-    <releaseNotes>Now works with Xamarin Studio 6.</releaseNotes>
-    <copyright>Copyright 2015-2016 Frank A. Krueger</copyright>
+    <description>Continuous Coding environment for .NET visualizes objects as quickly as you can code them. Get the Visual Studio for Mac add-in with the same name in order to use this library.</description>
+    <releaseNotes>Now works with Visual Studio for Mac 2019.</releaseNotes>
+    <copyright>Copyright 2015-2019 Frank A. Krueger</copyright>
     <tags>continuous code</tags>
     <dependencies>
       <dependency id="Newtonsoft.Json" version="8.0.3" />

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,15 @@
 all:
 
 nuget:
-	xbuild /p:Configuration=Release Continuous.Server.iOS/Continuous.Server.iOS.csproj
-	xbuild /p:Configuration=Release Continuous.Server.Android/Continuous.Server.Android.csproj
+	nuget restore Continuous.sln
+	msbuild /p:Configuration=Release Continuous.Server.iOS/Continuous.Server.iOS.csproj
+	msbuild /p:Configuration=Release Continuous.Server.Android/Continuous.Server.Android.csproj
 	nuget pack Continuous.nuspec
 
 mpack:
-	xbuild /p:Configuration=Release Continuous.Client.MonoDevelop/Continuous.Client.MonoDevelop.csproj
-	/Applications/Xamarin\ Studio.app/Contents/MacOS/mdtool setup pack Continuous.Client.MonoDevelop/bin/Release/Continuous.Client.MonoDevelop.dll
+	nuget restore Continuous.sln
+	msbuild /p:Configuration=Release Continuous.Client.MonoDevelop/Continuous.Client.MonoDevelop.csproj
+	/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup pack Continuous.Client.MonoDevelop/bin/Release/Continuous.Client.MonoDevelop.dll
 	mv Continuous.Client.MonoDevelop.Continuous.Client.MonoDevelop_*.mpack Continuous.Client.MonoDevelop/AddinRepo/Continuous.Client.MonoDevelop.mpack
-	/Applications/Xamarin\ Studio.app/Contents/MacOS/mdtool setup rep-build Continuous.Client.MonoDevelop/AddinRepo
+	/Applications/Visual\ Studio.app/Contents/MacOS/vstool setup rep-build Continuous.Client.MonoDevelop/AddinRepo
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,46 @@
+pool:
+  vmImage: 'macos-latest'
+  
+steps:
+- task: DotNetCoreInstaller@0
+  displayName: Install .NET Core SDK
+  name: install_dotnetcore_sdk
+  enabled: true
+  inputs:
+    packageType: 'sdk'
+    version: '2.1.500'
+    
+# create subdirs for final artifacts
+- task: Bash@3
+  inputs:
+    targetType: 'inline'
+    script: 'mkdir $(Build.ArtifactStagingDirectory)/nuget-dev && mkdir $(Build.ArtifactStagingDirectory)/nuget-release && mkdir $(Build.ArtifactStagingDirectory)/mpack'
+
+# pack release nuget using raw nuspec
+- task: Bash@3
+  inputs:
+    targetType: 'inline'
+    script: 'make nuget && mv Continuous.*.nupkg $(Build.ArtifactStagingDirectory)/nuget-release'
+
+# rewrite nuspec for preview releases
+- task: Bash@3
+  inputs:
+    targetType: 'inline'
+    script: 'dotnet tool install -g dotnet-script && $HOME/.dotnet/tools/dotnet-script build/version-nuspec.csx'
+
+# pack preview nuget using modified nuspec
+- task: Bash@3
+  inputs:
+    targetType: 'inline'
+    script: 'make nuget && mv Continuous.*.nupkg $(Build.ArtifactStagingDirectory)/nuget-dev'
+
+# build mpack (disabled because azure devops macOS images are not net472 friendly)
+#- task: Bash@3
+#  inputs:
+#    targetType: 'inline'
+#    script: 'make mpack && cp Continuous.Client.MonoDevelop/AddinRepo/Continuous.Client.MonoDevelop.mpack $(Build.ArtifactStagingDirectory)/mpack'
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathtoPublish: '$(Build.ArtifactStagingDirectory)' 
+    artifactName: 'drop' 

--- a/build/version-nuspec.csx
+++ b/build/version-nuspec.csx
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+const string dontRewriteEnv = "PRESERVE_NUSPECVERSION_BRANCHES";
+const string buildEnv = "BUILD_BUILDNUMBER";
+const string branchEnv = "BUILD_SOURCEBRANCHNAME";
+const string shaEnv = "BUILD_SOURCEVERSION";
+const string msgEnv = "BUILD_SOURCEVERSIONMESSAGE";
+
+const string nuspec = "Continuous.nuspec";
+
+var build = Environment.GetEnvironmentVariable(buildEnv);
+var branch = Environment.GetEnvironmentVariable(branchEnv);
+var sha = Environment.GetEnvironmentVariable(shaEnv);
+var msg = Environment.GetEnvironmentVariable(msgEnv);
+var ignoreBranches = Environment.GetEnvironmentVariable(dontRewriteEnv)?.Split(';')?.ToList() ?? new List<string>();
+
+if (new [] { build, branch, sha, msg }.Any(String.IsNullOrWhiteSpace))
+    throw new Exception($"Environment variables are not valid: {new { build, branch, sha, msg }}");
+
+var output = File.ReadAllText(nuspec);
+
+// set release notes to commit
+{
+    var match = "<releaseNotes>(?<releaseNotes>.*)</releaseNotes>";
+    var releaseNotes = $"{sha}: {msg}";
+    var replace = $"<releaseNotes>{releaseNotes}</releaseNotes>";
+    output = Regex.Replace(output, match, replace);
+}
+
+// replace version with build/branch details
+if (ignoreBranches.Contains(branch)) 
+    Console.WriteLine($"Not altering nuspec version for build from '{branch}' branch");
+else
+{
+    var match = "<version>(?<version>.*)</version>";
+    var replacementVersion = $"-b{build}-{branch}";
+    var replace = $"<version>${{version}}{replacementVersion}</version>";
+    output = Regex.Replace(output, match, replace);
+
+    Console.WriteLine($"Added {replacementVersion} to nuspec version");
+}
+
+File.WriteAllText(nuspec, output);


### PR DESCRIPTION
This PR aims to update the Continuous NuGet package for iOS and Android with a minimal set of maintenance-related changes, distinct from any additions to functionality that may come later. My current thinking is that this should:

- [x] Fix issue causing degradation of reload performance over extended sessions
- [x] Update iOS visualiser to be iOS 13 friendly (the default modal presentation style has changed)
- [x] ~Update misc references across the project (e.g. android target https://github.com/nathanielcook/Continuous/commit/333341ad3952b19f05cc30c0c273bbffaae76dae)~ (I looked closer and we probably don't need to do this)

I'll also add preview CI builds to a temporary MyGet feed for testing. At some point in the future we can sort out something more official. 